### PR TITLE
Move settings block to Middleman app initialization.

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,10 +4,10 @@ require 'capybara/rspec'
 require 'middleman-core'
 require 'middleman-core/rack'
 
-middleman_app = ::Middleman::Application.new
-
-Capybara.app = ::Middleman::Rack.new(middleman_app).to_app do
+middleman_app = ::Middleman::Application.new do
   set :root, File.expand_path(File.join(File.dirname(__FILE__), '..'))
   set :environment, :development
   set :show_exceptions, false
 end
+
+Capybara.app = ::Middleman::Rack.new(middleman_app).to_app


### PR DESCRIPTION
- Settings block was previously under Capybara.app.
- Environment settings in particular (and likely the other two) had no
  affect there.
- By placing the block in the Middleman app initialization, settings
  actually have affect.
